### PR TITLE
DM-23830: Add CBP package to lsst_distrib

### DIFF
--- a/ups/cbp.table
+++ b/ups/cbp.table
@@ -2,6 +2,5 @@ setupRequired(numpy)
 setupRequired(geom)
 setupRequired(sphgeom)
 setupRequired(afw)
-setupOptional(pipelines_lsst_io)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
Do not depend on pipelines_lsst_io — It depends on pipeline components, rather than vice versa.